### PR TITLE
Feature/create sti parent model product for stock and order item

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
   gem 'guard-rspec', require: false
+  gem 'shoulda'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,6 +299,12 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     shellany (0.0.1)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.4.1)
+      activesupport (>= 4.2.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -379,6 +385,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   seed-fu
   selenium-webdriver
+  shoulda
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Order < ApplicationRecord
-  has_many :items, class_name: 'OrderItem', foreign_key: :order_uuid, inverse_of: :order
+  has_many :items, class_name: 'OrderItem', foreign_key: :order_id, inverse_of: :order
   belongs_to :buyer, class_name: "User", foreign_key: "buyer_id"
 
   attribute :uuid, :string, default: -> { SecureRandom.uuid }

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
-class OrderItem < Stock
-  belongs_to :order, class_name: 'Order', foreign_key: :order_uuid
+class OrderItem < Product
+  belongs_to :order, class_name: 'Order', foreign_key: :order_id
+  attribute :state, default: :shipping
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Product < ApplicationRecord
+  belongs_to :game, dependent: :destroy
+  belongs_to :user, dependent: :destroy
+
+  delegate :name, :price, to: :game, prefix: true
+
+  validates_inclusion_of :type, in: %W(Stock OrderItem)
+  
+  include AASM
+  
+  enum state: { pending: 0, selling: 1, shipping: 2, sold: 3 }
+  
+  aasm column: :state, enum: true do
+    state :pending, initial: true
+    state :selling
+    state :shipping
+    state :sold
+
+    event :open, guard: :is_stock? do
+      transitions from: :pending, to: :selling
+    end
+    
+    event :close, guard: :is_stock? do
+      transitions from: :selling, to: :pending
+    end
+    
+    event :complete, guard: :is_order_item do
+      transitions from: :shipping, to: :sold
+    end
+  end
+
+  def is_stock?
+    self.type == 'Stock'
+  end
+
+  def is_order_item?
+    self.type == 'OrderItem'
+  end
+end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,33 +1,12 @@
 # frozen_string_literal: true
 
-class Stock < ApplicationRecord
-  include AASM
-
-  belongs_to :game, dependent: :destroy
-  belongs_to :user, dependent: :destroy
+class Stock < Product
+  
   scope :not_own_by_current_user, ->(user_id) { where.not(user_id: user_id) }
-
-  validates :user_id, uniqueness: { scope: :game_id, message: 'already has the stock of this game' }
-  delegate :id, :name, :price, to: :game, prefix: true
-
-  enum state: { pending: 0, selling: 1, shipping: 2, sold: 3}
-
-  attribute :type, default: 'Stock'
-
-  aasm column: :state, enum: true do
-    state :pending, initial: true
-    state :selling
-    state :shipping
-    state :sold
-
-    event :open do
-      transitions from: :pending, to: :selling
-    end
-
-    event :close do
-      transitions from: :selling, to: :pending
-    end
-  end
+  
+  validates_uniqueness_of :user_id, scope: :game_id, message: 'already has the stock of this game'
+  
+  attribute :state, default: :pending
 
   def is_users?(user_id)
     
@@ -35,8 +14,9 @@ class Stock < ApplicationRecord
   end
   
   def reduce_quantity!(num)
-    raise ArgumentError unless num > 0
+    raise ArgumentError unless num > 0 && quantity >= num
 
     decrement!(:quantity, num)
+    self.quantity
   end
 end

--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -3,7 +3,7 @@
   <div class='td'><%= stock.game_price %></div>
   <div class='td'><%= f.text_field :price, value: stock.price, class: 'form-control' %></div>
   <div class='td'><%= f.text_field :quantity, value: stock.quantity, class: 'form-control' %></div>
-  <div class='td'><%= f.select :state, Stock.states.keys, { selected: stock.state }, class: 'form-control'%></div>
+  <div class='td'><%= f.select :state, [:pending, :selling], { selected: stock.state }, class: 'form-control'%></div>
   <%= f.hidden_field :stock_id, value: stock.id %>
   <div class='td'><%= f.submit 'save', class: 'btn btn-primary form-control' %></div>
   <div class='td'><%=  link_to 'delete', stock_path(stock), method: 'delete', class: 'btn btn-danger', data: { confirm: 'Are You Sure You Want To Delete This Stock?' } %></div>

--- a/db/migrate/20200907100650_change_stocks_table_name_to_products.rb
+++ b/db/migrate/20200907100650_change_stocks_table_name_to_products.rb
@@ -1,0 +1,19 @@
+class ChangeStocksTableNameToProducts < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :stocks, [:user_id, :game_id]
+    remove_foreign_key :stocks, :games
+    remove_foreign_key :stocks, :users
+    rename_table :stocks, :products
+    add_foreign_key :products, :games
+    add_foreign_key :products, :users
+  end
+
+  def down
+    remove_foreign_key :products, :games
+    remove_foreign_key :products, :users
+    rename_table :products, :stocks
+    add_foreign_key :stocks, :games
+    add_foreign_key :stocks, :users
+    add_index :stocks, [:user_id, :game_id], unique: true
+  end
+end

--- a/db/migrate/20200908085507_change_product_column_order_uuid_to_order_id_.rb
+++ b/db/migrate/20200908085507_change_product_column_order_uuid_to_order_id_.rb
@@ -1,0 +1,11 @@
+class ChangeProductColumnOrderUuidToOrderId < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :products, :order_uuid, :order_id
+    reversible do |dir|
+      dir.up { change_column :products, :order_id, :integer, using: 'order_id::integer' }
+      dir.down { change_column :products, :order_id, :string, using: 'order_id::varchar' }
+    end
+    add_foreign_key :products, :orders
+    add_index :products, :order_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_30_063632) do
+ActiveRecord::Schema.define(version: 2020_09_08_085507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2020_08_30_063632) do
     t.index ["name"], name: "index_platforms_on_name", unique: true
   end
 
-  create_table "stocks", force: :cascade do |t|
+  create_table "products", force: :cascade do |t|
     t.bigint "game_id", null: false
     t.bigint "user_id", null: false
     t.integer "price", null: false
@@ -73,10 +73,10 @@ ActiveRecord::Schema.define(version: 2020_08_30_063632) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "type", null: false
-    t.string "order_uuid"
-    t.index ["game_id"], name: "index_stocks_on_game_id"
-    t.index ["user_id", "game_id"], name: "index_stocks_on_user_id_and_game_id", unique: true
-    t.index ["user_id"], name: "index_stocks_on_user_id"
+    t.integer "order_id"
+    t.index ["game_id"], name: "index_products_on_game_id"
+    t.index ["order_id"], name: "index_products_on_order_id"
+    t.index ["user_id"], name: "index_products_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 2020_08_30_063632) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "games", "platforms"
   add_foreign_key "orders", "users", column: "buyer_id"
-  add_foreign_key "stocks", "games"
-  add_foreign_key "stocks", "users"
+  add_foreign_key "products", "games"
+  add_foreign_key "products", "orders"
+  add_foreign_key "products", "users"
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :stock do
+  factory :product, class: Product do
     association :game, strategy: :create
     association :user, strategy: :create
     price { 500 }
@@ -14,6 +14,14 @@ FactoryBot.define do
 
     trait :selling do
       state { 1 }
+    end
+
+    factory :stock, class: Stock do
+      type { 'Stock' }
+    end
+
+    factory :order_item, class: OrderItem do
+      type { 'OrderItem' }
     end
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OrderItem, type: :model do
+  it { should belong_to(:order).class_name('Order').with_foreign_key(:order_id)}
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Product, type: :model do
+
+  it { should belong_to(:game).dependent(:destroy) } 
+  it { should belong_to(:user).dependent(:destroy) } 
+  it { should delegate_method(:name).to(:game).with_prefix }
+  it { should delegate_method(:price).to(:game).with_prefix }
+  it { should define_enum_for(:state).with_values([:pending, :selling, :shipping, :sold]) }
+  it { should have_db_index(:user_id) }
+  it { should have_db_index(:game_id) }
+  it { should have_db_index(:order_id) }
+  it { should validate_inclusion_of(:type).in_array(%W(Stock OrderItem)) }
+
+  let(:product) { create(:product, type: type) }
+  let(:type) { "" }
+
+  describe "#is_stock?" do
+    subject { product.is_stock? }
+
+    context 'when type is not stock' do
+      let(:type) { 'OrderItem' }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when type is stock' do
+      let(:type) { 'Stock' }
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#is_order_item?" do
+    subject { product.is_order_item? }
+    let(:type) { 'Stock' }
+    context 'when type is not order_item' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when type is order item' do
+      let(:type) { 'OrderItem' }
+      it { is_expected.to be_truthy }
+    end
+  end
+  
+end

--- a/spec/models/stock_spec.rb
+++ b/spec/models/stock_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stock, type: :model do
+  let!(:stock) { create(:stock, quantity: 10) }
+
+  it { should validate_uniqueness_of(:user_id).scoped_to(:game_id).with_message('already has the stock of this game') }
+
+  describe "#reduce_quantity!" do
+    subject { stock.reduce_quantity!(num) }
+    
+    context 'when num is positive' do
+      let(:num) { 1 }
+      it { is_expected.to eq 9 }
+    end
+
+    context 'when num is negative' do
+      let(:num) { -1 }
+      it do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when num is more than quantity of stock' do
+      let(:num) { 20 }
+      it do 
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,3 +60,10 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Main Purpose:
* Create Product Model to become the parent model of stock & order_item. Extract association and AASM setting to it.
* Order and OrdeItem associate with order_id rather than order_uuid. (column also change from string to integer)
* Remove unique constraint in DB level of a user can have 1 stock record per game. Constraint still works at the model level.
* add gem shoulda and add the model relative test.