### PR TITLE
Feature/allow not register user to act with cart

### DIFF
--- a/app/controllers/concerns/has_cart.rb
+++ b/app/controllers/concerns/has_cart.rb
@@ -4,12 +4,34 @@ module HasCart
   extend ActiveSupport::Concern
 
   included do
-    helper_method :current_cart
+    helper_method :current_cart, :cart_user_id
 
     private
 
+    def set_cart_user_id
+      id = nil
+      
+      if current_user
+        id ||= current_user.id
+      end
+
+      if session[:cart_id]
+        id ||= session[:cart_id]
+      end
+
+      unless id
+        id = session[:cart_id] = SecureRandom.base64
+      end
+
+      id
+    end
+
+    def cart_user_id
+      @cart_user_id ||= set_cart_user_id
+    end
+
     def current_cart
-      @current_cart ||= Cart.new(current_user.id).decorate
+      @current_cart ||= Cart.new(cart_user_id).decorate
     end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,6 +2,9 @@
 
 class OrdersController < ApplicationController
   include HasCart
+
+  before_action :authenticate_user!
+  before_action :is_cart_any_item?
   
   def new
     @form = OrderForm.new(current_user.id)
@@ -17,6 +20,15 @@ class OrdersController < ApplicationController
       flash.now.alert = "Order cannot create !"
       render 'new'
     end
+  end
+
+  private
+
+  def is_cart_any_item?
+    return true if current_cart.items.any?
+
+    flash.alert = 'Your Cart is empty!'
+    redirect_to cart_path
   end
 
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -12,9 +12,17 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # end
 
   # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
+  def show
+    super
+    if @user.errors.empty? && session[:cart_id]
+        Cart.new(session[:cart_id]).register!(@user.id)
+      rescue Redis::CommandError => e
+        flash.alert = 'Cart has expired!'
+      ensure
+        session[:cart_id] = nil
+      end
+    end
+  end
 
   # protected
 

--- a/app/decorators/cart_item_decorator.rb
+++ b/app/decorators/cart_item_decorator.rb
@@ -27,6 +27,10 @@ class CartItemDecorator < ApplicationDecorator
     detail.fetch('owner_email')
   end
 
+  def owner_id
+    detail.fetch('owner_id')
+  end
+
   def stock_quantity
     detail.fetch('stock_quantity')
   end
@@ -34,7 +38,7 @@ class CartItemDecorator < ApplicationDecorator
   def to_order_item
     OrderItem.new(
       game_id: game_id,
-      user_id: user_id,
+      user_id: owner_id,
       price: price,
       quantity: quantity,
       state: 'shipping'

--- a/app/forms/order_form.rb
+++ b/app/forms/order_form.rb
@@ -4,7 +4,7 @@ class OrderForm
 
   include ActiveModel::Model
 
-  attr_accessor :user_id, :cart
+  attr_accessor :user_id, :cart, :order
   delegate :cart_items, :total_price, to: :cart
 
   def initialize(user_id)
@@ -14,14 +14,14 @@ class OrderForm
 
   def save
     ActiveRecord::Base.transaction do
-      order = Order.new(
+      @order = Order.new(
         buyer_id: user_id,
         price: cart.total_price
       )
       lock_stocks
       cart.checkout!
-      order.items = cart.cart_items.map(&:to_order_item)
-      order.save!
+      @order.items = cart.cart_items.map(&:to_order_item)
+      @order.save!
       cart.clear!
     end
   rescue Cart::CheckoutError => e

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -12,15 +12,13 @@ class CartItem
   
   validates :detail, presence: true
   validate :quantity_should_be_positive
-  validate :cannot_buy_user_own_stock
   validate :stock_should_be_latest, on: :checkout
   
-  attr_accessor :id, :stock_id, :user_id
+  attr_reader :id, :stock_id
   
-  def initialize(user_id, stock_id)
-    @user_id = user_id
+  def initialize(cart_id, stock_id)
     @stock_id = stock_id
-    @id = "#{user_id}:#{stock_id}"
+    @id = "#{cart_id}:#{stock_id}"
     
     if self.detail.nil?
       self.detail = detail_json
@@ -65,7 +63,8 @@ class CartItem
 
     stock.reduce_quantity!(quantity.value)
   end
-  
+
+
   private
 
   def detail_json
@@ -73,6 +72,7 @@ class CartItem
       game_id: stock.game_id,
       game_name: stock.game_name,
       owner_email: stock.user.email,
+      owner_id: stock.user.id,
       stock_quantity: stock.quantity
     }.to_json
   end
@@ -91,13 +91,6 @@ class CartItem
     return true unless quantity.value.negative?
 
     errors.add(:quantity, 'cannot be negative')
-    false
-  end
-
-  def cannot_buy_user_own_stock
-    return true if stock && !stock.is_users?(user_id)
-
-    errors.add(:user_id, 'cannot buy your own stock !')
     false
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -13,7 +13,7 @@ class Game < ApplicationRecord
   end
 
   def best_available_stock(user_id)
-    stocks.not_own_by_current_user(user_id).first
+    stocks.not_own_by_current_user(user_id.to_i).first
   end
 
   def total_quantity

--- a/app/operators/cart_add_operator.rb
+++ b/app/operators/cart_add_operator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class CartAddOperator
+
+  attr_reader :game_id, :stock_id, :quantity, :cart_user_id
+
+  def initialize(game_id: nil, stock_id: nil, quantity: 1, cart_user_id:)
+    @game_id = game_id
+    @stock_id = stock_id
+    @quantity = quantity
+    @cart_user_id = cart_user_id
+  end
+
+  def perform
+    raise InvalidInput unless valid_input?
+
+    if add_from_game?
+      @stock_id = best_available_stock.id
+    end 
+
+    cart.add_item(stock_id, quantity)
+  end
+
+  private
+  
+  def valid_input?
+    game_id || stock_id
+  end
+
+  def game
+    @game ||= Game.find(game_id)
+  end
+
+  def cart
+    Cart.new(cart_user_id)
+  end
+
+  def best_available_stock
+    @best_stock ||= game.best_available_stock(cart_user_id) #will be nil if no stock
+
+    raise NoStockExistError unless @best_stock
+
+    @best_stock
+  end
+
+  def add_from_game?
+    game_id && stock_id.nil?
+  end
+
+  class NoStockExistError < StandardError; end
+  class InvalidInput < StandardError; end
+end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -10,7 +10,7 @@
     <th></th>
   </thead>
   <tbody>
-    <% @current_cart.cart_items.each do |item| %>
+    <% current_cart.cart_items.each do |item| %>
       <tr>
         <td><%= link_to item.game_name, game_path(item.game_id) %></td>
         <td><%= item.price %></td>
@@ -30,7 +30,7 @@
       <td></td>
       <td></td>
       <td></td>
-      <td><%= @current_cart.total_price %></td>
+      <td><%= current_cart.total_price %></td>
       <td></td>
     </tr>
   </tbody>

--- a/app/views/games/_game_stock.html.erb
+++ b/app/views/games/_game_stock.html.erb
@@ -3,7 +3,7 @@
   <td><%= stock.quantity %></td>
   <td><%= stock.user.email %></td>
   <td>
-    <% unless stock.is_users?(current_user.id) %>
+    <% unless stock.is_users?(cart_user_id) %>
       <%= form_tag add_cart_path(params: {stock_id: stock.id}), method: 'post', remote: true, class:'form-inline' do %>
         <%= select_tag :quantity, options_for_select(1..stock.quantity), { class: 'form-control mr-5' } %>
         <%= submit_tag 'add!', class: 'btn btn-outline-success form-control'%>

--- a/app/views/shared/_head_bar.html.erb
+++ b/app/views/shared/_head_bar.html.erb
@@ -2,8 +2,8 @@
   <h5 class="my-0 mr-md-auto font-weight-normal"><%= link_to 'NextGame', root_path %></h5>
   <nav class="my-2 my-md-0 mr-md-3">
     <%= link_to 'Games', games_path, class: 'p-2 text-dark' %>
+    <%= link_to 'Cart', cart_path, class: 'p-2 text-dark' %>
     <% if user_signed_in? %>
-      <%= link_to 'Cart', cart_path, class: 'p-2 text-dark' %>
       <%= link_to 'Stock', stocks_path, class: 'p-2 text-dark' %>
       <%= link_to 'LogOut', destroy_user_session_path, method: 'delete', class: 'p-2 btn btn-outline-danger btn-sm' %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   root to: 'games#index'
-  devise_for :users, controllers: { sessions: 'users/sessions' }
+  devise_for :users, controllers: { confirmations: 'users/confirmations', }
 
   resources :games, only: %i[show index]
   resources :stocks, only: %i[index show create update destroy]

--- a/spec/concerns/has_cart_spec.rb
+++ b/spec/concerns/has_cart_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples_for "has_cart" do
+  let(:controller) { described_class.new } # the class that includes the concern
+  let(:user) { create(:user) }
+  let(:session) { Hash.new }
+
+  before { allow(controller).to receive(:session).and_return(session) }
+
+  describe "#cart_user_id" do
+    subject { controller.send(:cart_user_id) }
+
+    context 'when current_user exist' do
+      before { allow(controller).to receive(:current_user).and_return(user) }
+      it { is_expected.to eq user.id }
+    end
+
+    context 'when current_user not exist' do
+      before { allow(controller).to receive(:current_user).and_return(nil) }
+      
+      context 'with cart_id in session' do
+        before { session[:cart_id] = 'test id'}
+
+        it { is_expected.to eq 'test id' }
+      end
+
+      context 'without anything in session' do
+        before { allow(SecureRandom).to receive(:base64).and_return('test base64') }
+
+        it { is_expected.to eq 'test base64' }
+      end
+    end
+  end
+
+  describe "#current_cart" do
+    subject { controller.send(:current_cart) }
+    before { allow(controller).to receive(:current_user).and_return(user) }
+
+    it { is_expected.to be_decorated }
+    it { is_expected.to be_a Cart }
+  end
+end

--- a/spec/models/cart_item_spec.rb
+++ b/spec/models/cart_item_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CartItem, type: :model do
       game_id: stock.game_id,
       game_name: stock.game_name,
       owner_email: stock.user.email,
+      owner_id: stock.user.id,
       stock_quantity: stock.quantity
     }.to_json
   end
@@ -174,14 +175,5 @@ RSpec.describe CartItem, type: :model do
       before { item.quantity.value = -10 }
       it { is_expected.to be_falsey }
     end
-  end
-  
-
-  describe "#cannot_buy_user_own_stock" do
-    subject { item.send(:cannot_buy_user_own_stock) }
-
-    before { stock.update(user_id: user.id) }
-
-    it { is_expected.to be_falsey }
   end
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -147,4 +147,23 @@ RSpec.describe Cart do
       end
     end
   end
+
+  describe '#register!' do
+    let(:cart) { described_class.new('test_session_cart_id') }
+    before do
+      allow(cart.items).to receive(:rename).and_return(true)
+      allow(cart.uuid).to receive(:rename).and_return(true)
+    end
+
+    subject { cart.register!(user.id) }
+
+    it 'should change user_id' do
+      expect { subject }.to change { cart.user_id }.from('test_session_cart_id').to(user.id)
+    end
+    it 'should rename redis key of items and uuid' do
+      subject
+      expect(cart.items).to have_received(:rename).with("cart:#{user.id}:items")
+      expect(cart.uuid).to have_received(:rename).with("cart:#{user.id}:uuid")
+    end
+  end
 end

--- a/spec/operators/cart_add_operator_spec.rb
+++ b/spec/operators/cart_add_operator_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CartAddOperator do
+  let!(:user) { create(:user) }
+  let!(:game) { create(:game) }
+  let!(:stock) { create(:stock, :selling, game: game) }
+  let(:operator) { described_class.new(params) }
+
+  describe "#perform" do
+    subject { operator.perform }
+
+    before { allow_any_instance_of(Cart).to receive(:add_item) }
+
+    context 'when add from game' do
+      let(:params) { { game_id: game_id, quantity: 3, cart_user_id: user.id } }
+      
+      context 'and game has stocks' do
+        let(:game_id) { game.id }
+
+        it 'should add item to cart' do
+          expect_any_instance_of(Cart).to receive(:add_item).with(stock.id, 3)
+          subject
+        end
+
+        it 'should find best stock and assign to stock_id' do
+          expect { subject }.to change { operator.stock_id }.from(nil).to(stock.id)
+        end
+      end
+
+      context 'and game does not have stocks' do
+        let!(:game_without_stock) { create(:game) }
+        let(:game_id) { game_without_stock.id }
+
+        it 'should raise error NoStockExistError 'do
+          expect { subject }.to raise_error CartAddOperator::NoStockExistError
+        end
+      end
+
+      context 'and game does not exsit' do
+        let(:game_id) { 999999999 }
+
+        it 'should raise error ActiveRecord::RecordNotFound' do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+
+    context 'when add from stock' do
+      let(:params) { { stock_id: stock.id, quantity: 3, cart_user_id: user.id } }
+
+      it 'should add item to cart' do
+        expect_any_instance_of(Cart).to receive(:add_item).with(stock.id, 3)
+        subject
+      end
+    end
+
+    context 'when param inpu invalid' do
+      let(:params) { { quantity: 3, cart_user_id: user.id } }
+
+      it 'should raise error InvalidInput' do
+        expect { subject }.to raise_error CartAddOperator::InvalidInput
+      end
+    end
+  end
+end


### PR DESCRIPTION
Main Purpose: Allow users to act with cart even not register.

Model:
* Cart adds new redis field uuid for recognizing and connecting to its items.
* current_cart now will be created not only with user_id but also cart_id (secure token )for session
* cart_item now will store the owner_id of stock (seller)
* cart_item no longer checks whether buying the user's own stock. (It will only happen if user doing irregular action)

Controller:
* user cart_user_id when need cart. It will first find user_id, else session's cart_id. If none feat, set session's cart_id.
* CartsController allow none register user to access
* OrdersController only allow registered user and cart need to have item
* add action has been extracted CartAddOperator
* When the user is confirmed, cart's redis key will be renamed to the user's id and session's cart_id will be clear